### PR TITLE
12 vnc loop

### DIFF
--- a/app/src/components/ui/spinner.tsx
+++ b/app/src/components/ui/spinner.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface SpinnerProps {
+  size?: 'small' | 'medium' | 'large';
+}
+
+const Spinner: React.FC<SpinnerProps> = ({ size = 'medium' }) => {
+  const sizeClasses = {
+    small: 'w-4 h-4 border-4',
+    medium: 'w-8 h-8 border-4',
+    large: 'w-12 h-12 border-4',
+  };
+
+  return (
+    <div className={`flex justify-center items-center`}>
+      <div
+        className={`border-4 border-slate-900 border-t-4 border-t-white rounded-full animate-spin ${sizeClasses[size]}`}
+      />
+    </div>
+  );
+};
+
+export default Spinner;

--- a/app/src/components/view-agent/VncViewer.tsx
+++ b/app/src/components/view-agent/VncViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { core } from '@tauri-apps/api';
 import { MessageInput } from './MessageInput';
+import Spinner from '../ui/spinner';
 
 interface VncViewerProps {
   agentId: string;
@@ -16,6 +17,9 @@ export function VncViewer({ agentId }: VncViewerProps) {
   const [container, setContainer] = useState<DockerContainer | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // just use localhost since we know that's the noVNC port
+  const vncUrl = "http://localhost:6080";
 
   useEffect(() => {
     let mounted = true;
@@ -54,15 +58,21 @@ export function VncViewer({ agentId }: VncViewerProps) {
   }, [agentId]);
 
   if (loading) {
-    return <div>Loading VNC viewer...</div>;
+    return (
+      <div className='flex justify-center items-center flex-col gap-2'>
+        <p>Loading VNC viewer...</p>
+        <Spinner size="medium"/>
+      </div>
+    );
   }
 
   if (error || !container) {
-    return <div>Failed to load VNC viewer: {error}</div>;
+    return (
+      <div className='flex justify-center items-center flex-col gap-2'>
+        <p>Failed to load VNC viewer: {error}</p>
+      </div>
+      );
   }
-
-  // Just use localhost:6080 since we know that's the noVNC port
-  const vncUrl = "http://localhost:6080";
 
   console.log('Connecting to VNC at:', vncUrl);
 

--- a/app/src/components/view-agent/VncViewer.tsx
+++ b/app/src/components/view-agent/VncViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { core } from '@tauri-apps/api';
 import { MessageInput } from './MessageInput';
-import Spinner from '@/components/ui/spinner.tsx';
+import Spinner from "@/components/ui/spinner.tsx";
 
 interface VncViewerProps {
   agentId: string;
@@ -18,35 +18,37 @@ export function VncViewer({ agentId }: VncViewerProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Just use localhost:6080 since we know that's the noVNC port
-  const vncUrl = `http://localhost:6080?timestamp=${Date.now()}`;
+  // Just use localhost:6080 since we know that's the noVNC port (if you want to test if it's being cached just add a unique query param e.g. date so it won't be cached)
+  const vncUrl = 'http://localhost:6080';
 
   useEffect(() => {
     let mounted = true;
 
     async function initContainer() {
-      try {
-        // Try to get existing container
-        let containerInfo = await core.invoke<DockerContainer | null>('get_agent_container', { agentId });
+        try {
+          // Try to get existing container
+          let containerInfo = await core.invoke<DockerContainer | null>('get_agent_container', { agentId });
 
-        // If no container exists and component is still mounted, create one
-        if (!containerInfo && mounted) {
-          containerInfo = await core.invoke<DockerContainer>('create_agent_container', { agentId });
-        }
+          // If no container exists and component is still mounted, create one
+          if (!containerInfo && mounted) {
+            containerInfo = await core.invoke<DockerContainer>('create_agent_container', { agentId });
+          }
 
-        if (mounted) {
-          setContainer(containerInfo);
-          setError(null);
-        }
-      } catch (error) {
-        console.error('Failed to initialize container:', error);
-        if (mounted) {
-          setError('Failed to initialize container');
-        }
-      } finally {
-        if (mounted) {
-          setLoading(false);
-        }
+          await new Promise(resolve => setTimeout(resolve, 3000));
+
+          if (mounted) {
+            setContainer(containerInfo);
+            setError(null);
+          }
+        } catch (error) {
+          console.error('Failed to initialize container:', error);
+          if (mounted) {
+            setError('Failed to initialize container');
+          }
+        } finally {
+          if (mounted) {
+            setLoading(false);
+          }
       }
     }
 
@@ -57,11 +59,11 @@ export function VncViewer({ agentId }: VncViewerProps) {
     };
   }, [agentId]);
 
-  if (!loading) {
+  if (loading) {
     return (
       <div className='flex justify-center items-center flex-col gap-2'>
         <p>Loading VNC viewer...</p>
-        <Spinner/>
+        <Spinner size="medium"/>
       </div>
     );
   }
@@ -71,7 +73,7 @@ export function VncViewer({ agentId }: VncViewerProps) {
       <div className='flex justify-center items-center flex-col gap-2'>
         <p>Failed to load VNC viewer: {error}</p>
       </div>
-    );
+      );
   }
 
   console.log('Connecting to VNC at:', vncUrl);
@@ -89,7 +91,7 @@ export function VncViewer({ agentId }: VncViewerProps) {
         promptRunning="false"
         currentAgentID={agentId}
         stopAgent={() => { }}
-        agentConnection={true}
+        agentConnection={!loading}
       />
     </>
   );

--- a/app/src/components/view-agent/VncViewer.tsx
+++ b/app/src/components/view-agent/VncViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { core } from '@tauri-apps/api';
 import { MessageInput } from './MessageInput';
-import Spinner from '../ui/spinner';
+import Spinner from '@/components/ui/spinner.tsx';
 
 interface VncViewerProps {
   agentId: string;
@@ -18,8 +18,8 @@ export function VncViewer({ agentId }: VncViewerProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // just use localhost since we know that's the noVNC port
-  const vncUrl = "http://localhost:6080";
+  // Just use localhost:6080 since we know that's the noVNC port
+  const vncUrl = `http://localhost:6080?timestamp=${Date.now()}`;
 
   useEffect(() => {
     let mounted = true;
@@ -57,11 +57,11 @@ export function VncViewer({ agentId }: VncViewerProps) {
     };
   }, [agentId]);
 
-  if (loading) {
+  if (!loading) {
     return (
       <div className='flex justify-center items-center flex-col gap-2'>
         <p>Loading VNC viewer...</p>
-        <Spinner size="medium"/>
+        <Spinner/>
       </div>
     );
   }
@@ -71,7 +71,7 @@ export function VncViewer({ agentId }: VncViewerProps) {
       <div className='flex justify-center items-center flex-col gap-2'>
         <p>Failed to load VNC viewer: {error}</p>
       </div>
-      );
+    );
   }
 
   console.log('Connecting to VNC at:', vncUrl);


### PR DESCRIPTION
Potential fix for #12 

Since we're trying to connect before `localhost:6080` or wherever vnc is running, unless it's cached, it won't render. 

- added a `3 second` delay after getting `containerInfo`, 3 is arbitrary number which is gives enough time for the port to be set up
- also added a neat little loading spinner component while vnc loads with 3 sizes (s,m,l) but that was just for fun 😄 

**Other things I tried**:
- brute force was just call initContainer twice (this worked but was just weird)
- made initContainer have an inner for loop that iterated twice (again worked but was just not clean)
- exponential backoff before recalling (this led to infinite loop as it wasn't actually reseting itself, it just kept calling on a failed connection so it would always lead to more failed connections)