### PR TITLE
Good first issue/add browser to docker image

### DIFF
--- a/app/src-tauri/Dockerfile
+++ b/app/src-tauri/Dockerfile
@@ -3,7 +3,13 @@ FROM ubuntu:22.04
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install minimal desktop environment, VNC server, and firefox
+# Add Mozilla PPA for Firefox
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:mozillateam/ppa && \
+    echo 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001' | tee /etc/apt/preferences.d/mozilla-firefox
+
+# Install minimal desktop environment, VNC server, and Firefox
 RUN apt-get update && apt-get install -y \
     xfce4 \
     xfce4-terminal \
@@ -16,6 +22,8 @@ RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
     python3-tk \
+    fonts-dejavu \
+    mesa-utils \
     firefox \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -52,9 +60,9 @@ RUN chmod +x /startup.sh /novnc_startup.sh /init.py
 # Create directory for logs and set permissions
 RUN mkdir -p /var/log/supervisor && \
     touch /var/log/supervisor/vnc.log \
-        /var/log/supervisor/vnc.err \
-        /var/log/supervisor/novnc.log \
-        /var/log/supervisor/novnc.err && \
+    /var/log/supervisor/vnc.err \
+    /var/log/supervisor/novnc.log \
+    /var/log/supervisor/novnc.err && \
     chown -R vncuser:vncuser /var/log/supervisor && \
     chmod 755 /var/log/supervisor && \
     chmod 644 /var/log/supervisor/*.log /var/log/supervisor/*.err

--- a/app/src-tauri/Dockerfile
+++ b/app/src-tauri/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install minimal desktop environment and VNC server
+# Install minimal desktop environment, VNC server, and firefox
 RUN apt-get update && apt-get install -y \
     xfce4 \
     xfce4-terminal \
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
     python3-tk \
+    firefox \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Okay sorry successfully added firefox #6 and got it running and is able to be used normally.

- Ubuntu 22 moved away from apt-get for ff and switched to snap
- Used Mozilla PPA to avoid this issue